### PR TITLE
Get front page redirects working

### DIFF
--- a/src/EventSubscriber/GlobalredirectSubscriber.php
+++ b/src/EventSubscriber/GlobalredirectSubscriber.php
@@ -144,8 +144,6 @@ class GlobalredirectSubscriber implements EventSubscriberInterface {
    * @param \Symfony\Component\HttpKernel\Event\GetResponseEvent $event
    */
   public function globalredirectFrontPage(GetResponseEvent $event) {
-    // @todo get front page redirects working.
-    return;
     if (!$this->config->get('frontpage_redirect')) {
       return;
     }
@@ -153,8 +151,9 @@ class GlobalredirectSubscriber implements EventSubscriberInterface {
     $request = $event->getRequest();
     $path = trim($request->getPathInfo(), '/');
 
-    // Redirect only if the current path is not the root.
-    if (!empty($path)) {
+    // Redirect only if the current path is not the root and this is the front
+    // page.
+    if (!empty($path) && $path == \Drupal::config('system.site')->get('page.front')) {
       $this->setResponse($event, Url::fromRoute('<front>'));
     }
   }

--- a/src/Tests/GlobalRedirectTest.php
+++ b/src/Tests/GlobalRedirectTest.php
@@ -41,9 +41,10 @@ class GlobalRedirectTest extends WebTestBase {
    */
   protected $config;
 
-  protected $forumTerm;
-  protected $term;
-  protected $node;
+  /**
+   * @var \Drupal\Core\Entity\ContentEntityInterface
+   */
+  protected $forumTerm, $term, $node;
 
   /**
    * {@inheritdoc}

--- a/src/Tests/GlobalRedirectTest.php
+++ b/src/Tests/GlobalRedirectTest.php
@@ -44,7 +44,17 @@ class GlobalRedirectTest extends WebTestBase {
   /**
    * @var \Drupal\Core\Entity\ContentEntityInterface
    */
-  protected $forumTerm, $term, $node;
+  protected $forumTerm;
+
+  /**
+   * @var \Drupal\Core\Entity\ContentEntityInterface
+   */
+  protected $term;
+
+  /**
+   * @var \Drupal\Core\Entity\ContentEntityInterface
+   */
+  protected $node;
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
This gets front page redirect functionality working, and all tests pass. Note, I attempted to use `PathMatcher::isFrontPage()`, but that wasn't working (perhaps too early in the bootstrap process?).
