### PR TITLE
Properly redirect aliases of the front page.

### DIFF
--- a/src/EventSubscriber/GlobalredirectSubscriber.php
+++ b/src/EventSubscriber/GlobalredirectSubscriber.php
@@ -154,7 +154,7 @@ class GlobalredirectSubscriber implements EventSubscriberInterface {
 
     // Redirect only if the current path is not the root and this is the front
     // page.
-    if (!empty($path) && $path == \Drupal::config('system.site')->get('page.front')) {
+    if ($this->isFrontPage($path)) {
       $this->setResponse($event, Url::fromRoute('<front>'));
     }
   }
@@ -234,4 +234,26 @@ class GlobalredirectSubscriber implements EventSubscriberInterface {
     $events[KernelEvents::REQUEST][] = array('globalredirectForum', 37);
     return $events;
   }
+
+  /**
+   * Determine if the given path is the site's front page.
+   *
+   * @param string $path
+   *   The path to check.
+   *
+   * @return bool
+   *   Returns TRUE if the path is the site's front page.
+   */
+  protected function isFrontPage($path) {
+    // @todo PathMatcher::isFrontPage() doesn't work here for some reason.
+    $front = \Drupal::config('system.site')->get('page.front');
+
+    // This might be an alias.
+    $alias_path = \Drupal::service('path.alias_manager')->getPathByAlias($path);
+
+    return !empty($path)
+      // Path matches front or alias to front.
+      && (($path == $front) || ($alias_path == $front));
+  }
+
 }

--- a/src/Tests/GlobalRedirectTest.php
+++ b/src/Tests/GlobalRedirectTest.php
@@ -146,8 +146,13 @@ class GlobalRedirectTest extends WebTestBase {
     $this->config('system.site')->set('page.front', 'node')->save();
     $this->assertRedirect('node', '<front>');
 
+    // Test front page redirects with an alias.
+    \Drupal::service('path.alias_storage')->save('node', 'node-alias');
+    $this->assertRedirect('node-alias', '<front>');
+
     $this->config->set('frontpage_redirect', FALSE)->save();
     $this->assertRedirect('node', NULL, 'HTTP/1.1 200 OK');
+    $this->assertRedirect('node-alias', NULL, 'HTTP/1.1 200 OK');
 
     // Test the access checking.
 


### PR DESCRIPTION
Aliases to the front page were not previously redirected to the front
page.
