### PR TITLE
Added subscriber to invalidate the 'rendered' cache tag when saving settings

### DIFF
--- a/globalredirect.services.yml
+++ b/globalredirect.services.yml
@@ -7,3 +7,8 @@ services:
   globalredirect.checker:
     class: Drupal\globalredirect\RedirectChecker
     arguments: ['@config.factory', '@access_manager', '@current_user', '@router.route_provider']
+  globalredirect.settings_cache_tag:
+    class: Drupal\globalredirect\EventSubscriber\GlobalredirectSettingsCacheTag
+    arguments: ['@cache_tags.invalidator']
+    tags:
+      - { name: event_subscriber }

--- a/src/EventSubscriber/GlobalredirectSettingsCacheTag.php
+++ b/src/EventSubscriber/GlobalredirectSettingsCacheTag.php
@@ -41,7 +41,7 @@ class GlobalredirectSettingsCacheTag implements EventSubscriberInterface {
    *   The Event to process.
    */
   public function onSave(ConfigCrudEvent $event) {
-    // Changing the Global Redirect settings means that any cache page might
+    // Changing the Global Redirect settings means that any cached page might
     // result in a different response, so we need to invalidate them all.
     if ($event->getConfig()->getName() === 'globalredirect.settings') {
       $this->cacheTagsInvalidator->invalidateTags(['rendered']);

--- a/src/EventSubscriber/GlobalredirectSettingsCacheTag.php
+++ b/src/EventSubscriber/GlobalredirectSettingsCacheTag.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\globalredirect\EventSubscriber\GlobalredirectSettingsCacheTag.
+ */
+
+namespace Drupal\globalredirect\EventSubscriber;
+
+use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
+use Drupal\Core\Config\ConfigCrudEvent;
+use Drupal\Core\Config\ConfigEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * A subscriber invalidating the 'rendered' cache tag when saving globalredirect settings.
+ */
+class GlobalredirectSettingsCacheTag implements EventSubscriberInterface {
+
+  /**
+   * The cache tags invalidator.
+   *
+   * @var \Drupal\Core\Cache\CacheTagsInvalidatorInterface
+   */
+  protected $cacheTagsInvalidator;
+
+  /**
+   * Constructs a GlobalredirectSettingsCacheTag object.
+   *
+   * @param \Drupal\Core\Cache\CacheTagsInvalidatorInterface $cache_tags_invalidator
+   *   The cache tags invalidator.
+   */
+  public function __construct(CacheTagsInvalidatorInterface $cache_tags_invalidator) {
+    $this->cacheTagsInvalidator = $cache_tags_invalidator;
+  }
+
+  /**
+   * Invalidate the 'rendered' cache tag whenever the settings are modified.
+   *
+   * @param \Drupal\Core\Config\ConfigCrudEvent $event
+   *   The Event to process.
+   */
+  public function onSave(ConfigCrudEvent $event) {
+    // Globalredirect settings.
+    if ($event->getConfig()->getName() === 'globalredirect.settings') {
+      $this->cacheTagsInvalidator->invalidateTags(['rendered']);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events[ConfigEvents::SAVE][] = ['onSave'];
+    return $events;
+  }
+
+}

--- a/src/EventSubscriber/GlobalredirectSettingsCacheTag.php
+++ b/src/EventSubscriber/GlobalredirectSettingsCacheTag.php
@@ -41,7 +41,8 @@ class GlobalredirectSettingsCacheTag implements EventSubscriberInterface {
    *   The Event to process.
    */
   public function onSave(ConfigCrudEvent $event) {
-    // Globalredirect settings.
+    // Changing the Global Redirect settings means that any cache page might
+    // result in a different response, so we need to invalidate them all.
     if ($event->getConfig()->getName() === 'globalredirect.settings') {
       $this->cacheTagsInvalidator->invalidateTags(['rendered']);
     }

--- a/src/EventSubscriber/GlobalredirectSubscriber.php
+++ b/src/EventSubscriber/GlobalredirectSubscriber.php
@@ -216,7 +216,7 @@ class GlobalredirectSubscriber implements EventSubscriberInterface {
 
     // We can only check access for routed URLs.
     if (!$url->isRouted() || $this->redirectChecker->canRedirect($url->getRouteName(), $request)) {
-      // Add the rendered cache tag, so that we can invalidate all responses
+      // Add the 'rendered' cache tag, so that we can invalidate all responses
       // when settings are changed.
       $headers = [
         'X-Drupal-Cache-Tags' => 'rendered',

--- a/src/EventSubscriber/GlobalredirectSubscriber.php
+++ b/src/EventSubscriber/GlobalredirectSubscriber.php
@@ -216,7 +216,12 @@ class GlobalredirectSubscriber implements EventSubscriberInterface {
 
     // We can only check access for routed URLs.
     if (!$url->isRouted() || $this->redirectChecker->canRedirect($url->getRouteName(), $request)) {
-      $event->setResponse(new RedirectResponse($url->toString(), 301));
+      // Add the rendered cache tag, so that we can invalidate all responses
+      // when settings are changed.
+      $headers = [
+        'X-Drupal-Cache-Tags' => 'rendered',
+      ];
+      $event->setResponse(new RedirectResponse($url->toString(), 301, $headers));
     }
   }
 

--- a/src/Tests/GlobalRedirectTest.php
+++ b/src/Tests/GlobalRedirectTest.php
@@ -6,10 +6,8 @@
 
 namespace Drupal\globalredirect\Tests;
 
-use Drupal\Component\Utility\String;
-use Drupal\Component\Utility\UrlHelper;
+use Drupal\Component\Utility\SafeMarkup;
 use Drupal\Core\Language\Language;
-use Drupal\Core\Routing\UrlGenerator;
 use Drupal\simpletest\WebTestBase;
 
 /**
@@ -193,7 +191,7 @@ class GlobalRedirectTest extends WebTestBase {
     $headers = $this->drupalGetHeaders(TRUE);
 
     $ending_url = isset($headers[0]['location']) ? $headers[0]['location'] : NULL;
-    $message = String::format('Testing redirect from %from to %to. Ending url: %url', array('%from' => $path, '%to' => $expected_ending_url, '%url' => $ending_url));
+    $message = SafeMarkup::format('Testing redirect from %from to %to. Ending url: %url', array('%from' => $path, '%to' => $expected_ending_url, '%url' => $ending_url));
 
     if ($expected_ending_url == '<front>') {
       $expected_ending_url = $GLOBALS['base_url'] . '/';


### PR DESCRIPTION
Added subscriber to invalidate the 'rendered' cache tag when saving globalredirect settings.
Removed some unused classes in GlobalredirectTest, changed String::format() to SafeMarkup::format().
